### PR TITLE
Fix build config and add skip-track feature

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "lecteur_mp3_reborn.c" "playlist_manager.c" "audio_manager.c" "bt_control.c"
+idf_component_register(SRCS "main.c" "playlist_manager.c" "audio_manager.c" "bt_control.c"
                     INCLUDE_DIRS "."
                     PRIV_REQUIRES
                     )

--- a/main/audio_manager.c
+++ b/main/audio_manager.c
@@ -89,6 +89,23 @@ esp_bt_gap_start_discovery(ESP_BT_INQ_MODE_GENERAL_INQUIRY, 5, 0);
     return ESP_OK;
 }
 
+esp_err_t audio_manager_next(void) {
+    if (!pipeline) return ESP_FAIL;
+
+    audio_pipeline_stop(pipeline);
+    audio_pipeline_wait_for_stop(pipeline);
+
+    const char *next_uri = playlist_manager_get_next();
+    audio_element_set_uri(fatfs_reader, next_uri);
+    ESP_LOGI(TAG, "Skipping to: %s", next_uri);
+    audio_pipeline_reset_ringbuffer(pipeline);
+    audio_pipeline_reset_elements(pipeline);
+    audio_pipeline_change_state(pipeline, AEL_STATE_INIT);
+    audio_pipeline_run(pipeline);
+
+    return ESP_OK;
+}
+
 esp_err_t audio_manager_stop(void) {
     ESP_LOGI(TAG, "Stopping audio pipeline");
     if (!pipeline) return ESP_FAIL;

--- a/main/audio_manager.h
+++ b/main/audio_manager.h
@@ -19,6 +19,11 @@ esp_err_t audio_manager_start(void);
  */
 esp_err_t audio_manager_stop(void);
 
+/**
+ * @brief Passe immédiatement au morceau suivant.
+ */
+esp_err_t audio_manager_next(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/playlist_manager.c
+++ b/main/playlist_manager.c
@@ -131,3 +131,11 @@ size_t playlist_manager_get_current_index(void) {
     return current_index;
 }
 
+const char *playlist_manager_get_current_track(void) {
+    if (track_count == 0) {
+        return NULL;
+    }
+    size_t idx = current_index > 0 ? current_index - 1 : 0;
+    return track_list[shuffle_order[idx]];
+}
+

--- a/main/playlist_manager.h
+++ b/main/playlist_manager.h
@@ -35,6 +35,11 @@ size_t playlist_manager_get_track_count(void);
  */
 size_t playlist_manager_get_current_index(void);
 
+/**
+ * @brief Retourne le chemin du morceau actuellement sélectionné.
+ */
+const char *playlist_manager_get_current_track(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- fix component source list in `main/CMakeLists.txt`
- expose new `audio_manager_next()` API
- provide helper to return current track from playlist

## Testing
- `make` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f5749ded0832b9438bf1be63ddffc