### PR TITLE
Fix and enhance Bluetooth control

### DIFF
--- a/main/bt_control.h
+++ b/main/bt_control.h
@@ -4,5 +4,7 @@
 #include "esp_err.h"
 
 esp_err_t bt_control_init(void);
+void bt_control_start_discovery(void);
+bool bt_control_is_connected(void);
 
 #endif


### PR DESCRIPTION
## Summary
- add API to start Bluetooth device discovery and expose connection status
- initialize A2DP source and set scan mode

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f64a51104832bbdb8652e4d140986