### PR TITLE
Improve playlist robustness and add pause/resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /managed_components/
+esp-adf/

--- a/main/audio_manager.c
+++ b/main/audio_manager.c
@@ -119,6 +119,20 @@ esp_err_t audio_manager_prev(void)
     return change_track(prev_uri);
 }
 
+esp_err_t audio_manager_pause(void)
+{
+    if (!pipeline) return ESP_FAIL;
+    ESP_LOGI(TAG, "Pausing audio pipeline");
+    return audio_pipeline_pause(pipeline);
+}
+
+esp_err_t audio_manager_resume(void)
+{
+    if (!pipeline) return ESP_FAIL;
+    ESP_LOGI(TAG, "Resuming audio pipeline");
+    return audio_pipeline_resume(pipeline);
+}
+
 esp_err_t audio_manager_play(const char *path)
 {
     return change_track(path);

--- a/main/audio_manager.h
+++ b/main/audio_manager.h
@@ -30,6 +30,16 @@ esp_err_t audio_manager_next(void);
 esp_err_t audio_manager_prev(void);
 
 /**
+ * @brief Met en pause la lecture courante.
+ */
+esp_err_t audio_manager_pause(void);
+
+/**
+ * @brief Reprend la lecture après une pause.
+ */
+esp_err_t audio_manager_resume(void);
+
+/**
  * @brief Lit immediatement le fichier specifie.
  */
 esp_err_t audio_manager_play(const char *path);

--- a/main/main.c
+++ b/main/main.c
@@ -95,7 +95,9 @@ esp_err_t play_handler(httpd_req_t *req) {
 
 esp_err_t ctl_handler(httpd_req_t *req) {
     if (strcmp(req->uri, "/pause")==0) {
-        audio_manager_stop();
+        audio_manager_pause();
+    } else if (strcmp(req->uri, "/resume")==0) {
+        audio_manager_resume();
     } else if (strcmp(req->uri, "/next")==0) {
         audio_manager_next();
     } else if (strcmp(req->uri, "/previous")==0) {
@@ -129,12 +131,14 @@ void start_httpd() {
     httpd_uri_t list_uri = {"/list", HTTP_GET, list_handler, NULL};
     httpd_uri_t play_uri = {"/play", HTTP_GET, play_handler, NULL};
     httpd_uri_t pause_uri = {"/pause", HTTP_GET, ctl_handler, NULL};
+    httpd_uri_t resume_uri = {"/resume", HTTP_GET, ctl_handler, NULL};
     httpd_uri_t next_uri = {"/next", HTTP_GET, ctl_handler, NULL};
     httpd_uri_t prev_uri = {"/previous", HTTP_GET, ctl_handler, NULL};
     httpd_uri_t current_uri = {"/current", HTTP_GET, current_handler, NULL};
     httpd_register_uri_handler(http_server, &list_uri);
     httpd_register_uri_handler(http_server, &play_uri);
     httpd_register_uri_handler(http_server, &pause_uri);
+    httpd_register_uri_handler(http_server, &resume_uri);
     httpd_register_uri_handler(http_server, &next_uri);
     httpd_register_uri_handler(http_server, &prev_uri);
     httpd_register_uri_handler(http_server, &current_uri);

--- a/main/playlist_manager.c
+++ b/main/playlist_manager.c
@@ -44,6 +44,10 @@ static esp_err_t scan_directory(void) {
 }
 
 static void shuffle_tracks(void) {
+    if (track_count == 0) {
+        current_index = 0;
+        return;
+    }
     for (size_t i = 0; i < track_count; i++) {
         shuffle_order[i] = i;
     }
@@ -103,6 +107,11 @@ esp_err_t err;
     esp_err_t scan_err = scan_directory();
     if (scan_err != ESP_OK) return scan_err;
 
+    if (track_count == 0) {
+        ESP_LOGW(TAG, "No MP3 files found");
+        return ESP_ERR_NOT_FOUND;
+    }
+
     if (load_shuffle_order() != ESP_OK) {
         shuffle_tracks();
         save_shuffle_order();
@@ -111,6 +120,9 @@ esp_err_t err;
 }
 
 const char *playlist_manager_get_next(void) {
+    if (track_count == 0) {
+        return NULL;
+    }
     if (current_index >= track_count) {
         shuffle_tracks();
         save_shuffle_order();

--- a/www/index.html
+++ b/www/index.html
@@ -12,6 +12,7 @@
   <div class="controls">
     <button onclick="sendCommand('play')">▶️ Play</button>
     <button onclick="sendCommand('pause')">⏸️ Pause</button>
+    <button onclick="sendCommand('resume')">▶️ Reprendre</button>
     <button onclick="sendCommand('next')">⏭️ Suivant</button>
   </div>
   <h2>Fichiers disponibles :</h2>


### PR DESCRIPTION
## Summary
- ignore `esp-adf` subtree
- handle empty playlists safely
- add pause/resume controls to audio manager and web UI

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `make check` *(fails: No rule to make target 'check'*)

------
https://chatgpt.com/codex/tasks/task_e_6846ed8c8994832bbf1c9df4e025875d